### PR TITLE
updated libpng to 1.5.4 - last link was broken. 

### DIFF
--- a/magick-installer.sh
+++ b/magick-installer.sh
@@ -13,7 +13,7 @@ function download() {
 
 download http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.13.1.tar.gz
 download http://nongnu.askapache.com/freetype/freetype-2.4.3.tar.gz
-download ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.2.tar.gz
+download ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.4.tar.gz
 download http://www.ijg.org/files/jpegsrc.v8b.tar.gz
 download http://download.osgeo.org/libtiff/tiff-3.9.4.tar.gz
 download http://voxel.dl.sourceforge.net/project/wvware/libwmf/0.2.8.4/libwmf-0.2.8.4.tar.gz
@@ -38,8 +38,8 @@ make
 sudo make install
 cd ..
 
-tar xzvf libpng-1.5.2.tar.gz
-cd libpng-1.5.2
+tar xzvf libpng-1.5.4.tar.gz
+cd libpng-1.5.4
 ./configure --prefix=/usr/local
 make clean
 make


### PR DESCRIPTION
Updated libpng to 1.5.4

I ran into an error making the libgd libraries for libwmf-0.2.8.4 on OSX 10.5.8

Undefined symbols:
  "_png_check_sig", referenced from:
      _gdImageCreateFromPngCtx in libgd.a(gd_png.o)
ld: symbol(s) not found
collect2: ld returned 1 exit status
make[2]: **\* [libwmf.la] Error 1
make[1]: **\* [check-recursive] Error 1
make: **\* [check-recursive] Error 1

Solved@http://www.bill.eccles.net/bills_words/2010/01/building-a-mac-os-x-server-106.html 

> the problem above is caused by the removal of the long-deprecated _png_check_sig from libpng as [described in the release notes, here.](http://www.libpng.org/pub/png/src/libpng-1.2.x-to-1.4.x-summary.txt)

Changing line 139 in libwmf-0.2.8.4/src/extra/gd/gd_png.c from 

```if (!png_check_sig (sig, 8))
     return NULL;                /\* bad signature */

``````
to 

```if (!png_sig_cmp (sig, 0, 8) == 0){
     return NULL;   /* bad signature */
}```             

fixed the problem for me.





``````
