### PR TITLE
Disable OpenCL support

### DIFF
--- a/magick-installer.sh
+++ b/magick-installer.sh
@@ -107,7 +107,7 @@ tar xzvf ImageMagick-6.6.7-0.tar.gz
 cd ImageMagick-6.6.7-0
 export CPPFLAGS=-I/usr/local/include
 export LDFLAGS=-L/usr/local/lib
-./configure --prefix=/usr/local --disable-static --without-fontconfig --with-modules --without-perl --without-magick-plus-plus --with-quantum-depth=8 --with-gs-font-dir=/usr/local/share/ghostscript/fonts --disable-openmp
+./configure --prefix=/usr/local --disable-opencl --disable-static --without-fontconfig --with-modules --without-perl --without-magick-plus-plus --with-quantum-depth=8 --with-gs-font-dir=/usr/local/share/ghostscript/fonts --disable-openmp
 make clean
 make
 sudo make install


### PR DESCRIPTION
This patch disables OpenCL support when compiling ImageMagick, as keeping it enabled causes the RMagick ruby gem to be unable to compile on Lion.

I am not sure of the exact issue, but disabling OpenCL makes RMagick happily compile and install.
