### PR TITLE
Updating libs

### DIFF
--- a/magick-installer.sh
+++ b/magick-installer.sh
@@ -19,7 +19,7 @@ download http://nongnu.askapache.com/freetype/freetype-2.4.9.tar.gz
 download http://downloads.sourceforge.net/project/libpng/libpng15/older-releases/1.5.11/libpng-1.5.11.tar.gz
 download http://www.imagemagick.org/download/delegates/jpegsrc.v8b.tar.gz
 download http://download.osgeo.org/libtiff/tiff-4.0.2.tar.gz
-download http://voxel.dl.sourceforge.net/project/wvware/libwmf/0.2.8.4/libwmf-0.2.8.4.tar.gz
+download http://hivelocity.dl.sourceforge.net/project/wvware/libwmf/0.2.8.4/libwmf-0.2.8.4.tar.gz
 download http://downloads.sourceforge.net/project/lcms/lcms/1.19/lcms-1.19.tar.gz
 download http://sourceforge.net/projects/ghostscript/files/GPL%20Ghostscript/9.06/ghostscript-9.06.tar.gz
 download http://hivelocity.dl.sourceforge.net/project/gs-fonts/gs-fonts/8.11%20%28base%2035%2C%20GPL%29/ghostscript-fonts-std-8.11.tar.gz

--- a/magick-installer.sh
+++ b/magick-installer.sh
@@ -22,7 +22,7 @@ download http://download.osgeo.org/libtiff/tiff-4.0.2.tar.gz
 download http://voxel.dl.sourceforge.net/project/wvware/libwmf/0.2.8.4/libwmf-0.2.8.4.tar.gz
 download http://downloads.sourceforge.net/project/lcms/lcms/1.19/lcms-1.19.tar.gz
 download http://sourceforge.net/projects/ghostscript/files/GPL%20Ghostscript/9.06/ghostscript-9.06.tar.gz
-download http://voxel.dl.sourceforge.net/project/gs-fonts/gs-fonts/8.11%20%28base%2035%2C%20GPL%29/ghostscript-fonts-std-8.11.tar.gz
+download http://hivelocity.dl.sourceforge.net/project/gs-fonts/gs-fonts/8.11%20%28base%2035%2C%20GPL%29/ghostscript-fonts-std-8.11.tar.gz
 download ftp://ftp.sunet.se/pub/multimedia/graphics/ImageMagick/ImageMagick-6.7.9-4.tar.gz
 
 

--- a/magick-installer.sh
+++ b/magick-installer.sh
@@ -14,36 +14,36 @@ function download() {
 mkdir magick-installer
 cd magick-installer
 
-download http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.13.1.tar.gz
-download http://nongnu.askapache.com/freetype/freetype-2.4.3.tar.gz
-download http://sourceforge.net/projects/libpng/files/libpng15/older-releases/1.5.5/libpng-1.5.5.tar.gz
+download http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz
+download http://nongnu.askapache.com/freetype/freetype-2.4.9.tar.gz
+download http://downloads.sourceforge.net/project/libpng/libpng15/older-releases/1.5.11/libpng-1.5.11.tar.gz
 download http://www.imagemagick.org/download/delegates/jpegsrc.v8b.tar.gz
-download http://download.osgeo.org/libtiff/tiff-3.9.4.tar.gz
+download http://download.osgeo.org/libtiff/tiff-4.0.2.tar.gz
 download http://voxel.dl.sourceforge.net/project/wvware/libwmf/0.2.8.4/libwmf-0.2.8.4.tar.gz
 download http://downloads.sourceforge.net/project/lcms/lcms/1.19/lcms-1.19.tar.gz
-download http://sourceforge.net/projects/ghostscript/files/GPL%20Ghostscript/9.04/ghostscript-9.04.tar.gz
+download http://sourceforge.net/projects/ghostscript/files/GPL%20Ghostscript/9.06/ghostscript-9.06.tar.gz
 download http://voxel.dl.sourceforge.net/project/gs-fonts/gs-fonts/8.11%20%28base%2035%2C%20GPL%29/ghostscript-fonts-std-8.11.tar.gz
-download ftp://ftp.sunet.se/pub/multimedia/graphics/ImageMagick/ImageMagick-6.6.7-0.tar.gz
+download ftp://ftp.sunet.se/pub/multimedia/graphics/ImageMagick/ImageMagick-6.7.9-4.tar.gz
 
 
-tar xzvf libiconv-1.13.1.tar.gz
-cd libiconv-1.13.1
+tar xzvf libiconv-1.14.tar.gz
+cd libiconv-1.14
 cd libcharset
 ./configure --prefix=/usr/local
 make
 sudo make install
 cd ../..
 
-tar xzvf freetype-2.4.3.tar.gz
-cd freetype-2.4.3
+tar xzvf freetype-2.4.9.tar.gz
+cd freetype-2.4.9
 ./configure --prefix=/usr/local
 make clean
 make
 sudo make install
 cd ..
 
-tar xzvf libpng-1.5.5.tar.gz
-cd libpng-1.5.5
+tar xzvf libpng-1.5.11.tar.gz
+cd libpng-1.5.11
 ./configure --prefix=/usr/local
 make clean
 make
@@ -62,8 +62,8 @@ sudo make install
 cd ..
 
 
-tar xzvf tiff-3.9.4.tar.gz
-cd tiff-3.9.4
+tar xzvf tiff-4.0.2.tar.gz
+cd tiff-4.0.2
 ./configure --prefix=/usr/local
 make clean
 make
@@ -89,8 +89,8 @@ sudo make install
 cd ..
 
 
-tar zxvf ghostscript-9.04.tar.gz
-cd ghostscript-9.04
+tar zxvf ghostscript-9.06.tar.gz
+cd ghostscript-9.06
 ./configure  --prefix=/usr/local
 make clean
 make
@@ -103,8 +103,8 @@ sudo mkdir -p /usr/local/share/ghostscript/fonts
 sudo mv -f fonts/* /usr/local/share/ghostscript/fonts
 
 
-tar xzvf ImageMagick-6.6.7-0.tar.gz
-cd ImageMagick-6.6.7-0
+tar xzvf ImageMagick-6.7.9-4.tar.gz
+cd ImageMagick-6.7.9-4
 export CPPFLAGS=-I/usr/local/include
 export LDFLAGS=-L/usr/local/lib
 ./configure --prefix=/usr/local --disable-static --without-fontconfig --with-modules --without-perl --without-magick-plus-plus --with-quantum-depth=8 --with-gs-font-dir=/usr/local/share/ghostscript/fonts --disable-openmp


### PR DESCRIPTION
Updated to use new lib versions (libiconv, freetype, libpng, tiff, ghostscript, imagemagick), tested on Mountain Lion 10.8
